### PR TITLE
Link out to confluent

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ Curator: [Alex Ellis](https://www.alexellis.io) - CNCF Ambassador, [OpenFaaS](ht
 
 * [bmc-toolbox](https://github.com/bmc-toolbox) - "bmc-toolbox is bunch of tools to ease BMC management"
 * [cobbler](https://github.com/cobbler/cobbler) - "Cobbler is a Linux installation server that allows for rapid setup of network installation environments"
+* [confluent](https://github.com/lenovo/confluent) - "Service for onboarding and management of baremetal server BMCs and PXE"
 * [Digital Rebar](https://rebar.digital) - "Digital Rebar is the data center automation, provisioning and infrastructure as code (IaC) platform designed with a cloud native architecture replacing Cobbler, Foreman, MaaS or similar technologies"
 * [foreman](https://github.com/theforeman/foreman) - "From provisioning and configuration to orchestration and monitoring, Foreman integrates with your existing infrastructure to make operations easier"
 * [ironic](https://github.com/openstack/ironic) "A service for managing and provisioning Bare Metal servers" - from OpenStack Foundation


### PR DESCRIPTION
Confluent is a project intended to help with onboarding and managing BMCs and also baremetal deployment.

In the current release, it can help with onboarding of various things by allowing declaration of configuration either according to switch port or by serial number or a number of manual processes.

The naming scheme is completely customizable, but as one example one could have 'r3u32' name be bound to whatever was plugged into switch 'r3e1' port '32'.  When something does get plugged in it can have username, password, and IP address pushed to it, even without a DHCP server.

Alternatively, it can take a spreadsheet of serial numbers if the switches are not allowed or infeasible.

This can currently:
-Collect generic mac addresses or UUID for PXE
-Setup Lenovo IMM, SMM, or XCC devices
-List Lenovo CNOS devices

Once configured, it can do en-masse power control, health assessment, remote media management, serial console control and playback, event log, sensors, and others.

It additionally supports a collective mode with integrated HA and ability to distribute and redistribute load without the caller having to be aware.

It's premature to describe it fully, but next release will also add OS deployment support, including:
-Full use of fully validated TLS for entire deployment flow (can opt into less secure methods)
-Support of Secureboot (when opting into tftp bootstrap, this is also opted out of).
-Automatic console detection from ACPI for serial consoles
-Support either HTTP boot, PXE, or media based kickoff of deployment
-No dhcpd or dnsmasq required, but fully compatible with either
-SSH CA support for known_hosts management and enabling node-to-node host based authentication
