### PR TITLE
Added oVirt and FastHosts

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,7 @@ Curator: [Alex Ellis](https://www.alexellis.io) - CNCF Ambassador, [OpenFaaS](ht
 * [AlibabaCloud bare metal](https://www.alibabacloud.com/product/ebm) - `x86_64` & `arm64`
 * [AWS bare metal](https://aws.amazon.com/blogs/aws/category/compute/amazon-ec2-bare-metal/)  - `x86_64` & `arm64`
 * [cherryservers.com](https://www.cherryservers.com) - `x86_64`
+* [FastHosts bare metal] (https://www.fasthosts.co.uk/dedicated-servers) - `x86_x64`
 * [OVHcloud bare metal](https://www.ovh.com/world/dedicated-servers) - `x86_64`
 * [Packet bare metal infrastructure](https://www.packet.com) - `x86_64` & `arm64`
 * [Scaleway.com](https://www.scaleway.com) - `x86_64` & `arm64`
@@ -64,6 +65,7 @@ Curator: [Alex Ellis](https://www.alexellis.io) - CNCF Ambassador, [OpenFaaS](ht
 
 This section is for projects like Proxmox, for where the community feel strongly, but their submission doesn't fit into the bare-metal category.
 
+* [oVirt](https://www.ovirt.org/) - "oVirt is an open-source distributed virtualization solution, designed to manage your entire enterprise infrastructure. oVirt uses the trusted KVM hypervisor and is built upon several other community projects, including libvirt, Gluster, PatternFly, and Ansible."
 * [Proxmox VE](https://www.proxmox.com/en/proxmox-ve/get-started) - "Proxmox VE is a complete open-source platform for all-inclusive enterprise virtualization that tightly integrates KVM hypervisor and LXC containers, software-defined storage and networking functionality on a single platform"
 
 ## Appendix


### PR DESCRIPTION
* FastHosts is a competitive UK Based hosting company
offering bare metal dedicated servers
* oVirt is a community driven enterprise virtualisation
platform sponsored by RedHat

Signed-off-by: Matt Kimberley <matt.kimberley@hotmail.com>

Please fill out the whole template. If you delete or ignore the template, the PR will be closed.

## Project name

oVirt - An enterprise grade hypervisor platform that is community driven and sponsored by RedHat. Comparable to major proprietary offerings, oVirt provides highly scalable and available infrastructure that can be automated via a fully documented API. Many open source projects including Ansible and Terraform now integrate with this API, allowing a multitude of options to manage infrastructure at scale

FastHosts - A traditional web hosting company that has been in business since 1999 offering UK based or global datacentres. Their Dedicated servers offer 24/7 friendly support and unlimited 1Gb/s bandwidth. 

## Why do you feel this project should be added to awesome-baremetal?

oVirt - Having seen this at scale, hosting a large scale OpenShift platform with a fully automated deployment (from baremetal to container) I would not think twice about recommending oVirt as a hypervisor platform for "interal clouds"

FastHosts - A great organisation with a long well earned customer base. Their dedicated servers offer speed and reliability

## What's your connection to the project?

A) Author / creator
B) Contributor
C) User
D) Just heard of it, but haven't used it

Selection: C

## Submission type

1) Open Source bare-metal provisioning tool
2) Open Source networking tool
3) Open Source Hypervisor for use with bare-metal

Selection: 1+3


## Has the project had commits within the last 6 months?

Yes

