### PR TITLE
Updated Talos Systems to Sidero Labs

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ Curator: [Alex Ellis](https://www.alexellis.io) - CNCF Ambassador, [OpenFaaS](ht
 * [plundr](https://github.com/plunder-app/plunder) - "Plunder is a single-binary server that is all designed in order to make the provisioning of servers, platforms and applications easier." - with ClusterAPI support
 * [RackHD](https://rackhd.readthedocs.io/en/latest/) - "a technology stack for enabling automated hardware management and orchestration through cohesive APIs. It serves as an abstraction layer between other management layers and the underlying, vendor-specific physical hardware."
 * [Razor](https://github.com/puppetlabs/razor-server) - "Razor is next generation provisioning software that handles bare metal hardware and virtual server provisioning"
-* [Talos Systems](https://www.talos-systems.com/blog/building-arges-part-one-a-new-tool-for-datacenter-management/) - "A New Tool for Kubernetes Bare Metal" - with ClusterAPI support
+* [Sidero Labs](https://www.siderolabs.com/platform/bare-metal-kubernetes-sidero/) - "A New Tool for Kubernetes Bare Metal" - with ClusterAPI support
 * [Tinkerbell](https://tinkerbell.org) - "Tinkerbell is a bare metal provisioning engine. It’s built and maintained with love by the team at Equinix Metal."
 
 ## Networking for bare-metal cloud

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ Curator: [Alex Ellis](https://www.alexellis.io) - CNCF Ambassador, [OpenFaaS](ht
 * [plundr](https://github.com/plunder-app/plunder) - "Plunder is a single-binary server that is all designed in order to make the provisioning of servers, platforms and applications easier." - with ClusterAPI support
 * [RackHD](https://rackhd.readthedocs.io/en/latest/) - "a technology stack for enabling automated hardware management and orchestration through cohesive APIs. It serves as an abstraction layer between other management layers and the underlying, vendor-specific physical hardware."
 * [Razor](https://github.com/puppetlabs/razor-server) - "Razor is next generation provisioning software that handles bare metal hardware and virtual server provisioning"
-* [Sidero Labs](https://www.siderolabs.com/platform/bare-metal-kubernetes-sidero/) - "A New Tool for Kubernetes Bare Metal" - with ClusterAPI support
+* [Sidero Labs](https://www.siderolabs.com/platform/bare-metal-kubernetes-sidero/) - (Formerly known as Talos Systems) "A New Tool for Kubernetes Bare Metal" - with ClusterAPI support
 * [Tinkerbell](https://tinkerbell.org) - "Tinkerbell is a bare metal provisioning engine. It’s built and maintained with love by the team at Equinix Metal."
 
 ## Networking for bare-metal cloud


### PR DESCRIPTION
As of October 4th, Talos Systems has rebranded to Sidero Labs. Reference: https://www.siderolabs.com/blog/talos-systems-is-now-sidero-labs/

Please fill out the whole template. If you delete or ignore the template, the PR will be closed.

## Project name

Sidero Labs

## Why do you feel this project should be added to awesome-baremetal?

Name change

## What's your connection to the project?

A) Author / creator
B) Contributor
C) User
D) Just heard of it, but haven't used it

Selection: C

## Submission type

1) Open Source bare-metal provisioning tool
2) Open Source networking tool
3) Open Source Hypervisor for use with bare-metal

Selection: 1


## Has the project had commits within the last 6 months?

Yes